### PR TITLE
Add Tableau Public Gallery to Dashboards & BI Resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Ttutorials for building and enhancing dashboards and visualizations using variou
 - [Dash Enterprise Samples](https://github.com/plotly/dash-sample-apps) - Production-ready Dash apps.
 - [geeksforgeeks - Tableau Tutorial](https://www.geeksforgeeks.org/tableau-tutorial/) - Comprehensive tutorial on Tableau.
 - [geeksforgeeks - Power BI Tutorial](https://www.geeksforgeeks.org/power-bi-tutorial/) - Detailed tutorial on Power BI.
+- [Tableau Public Gallery](https://public.tableau.com/app/discover) - A curated collection of real-world interactive dashboards to inspire and learn from.
 
 [⬆ back to contents](#contents)
 


### PR DESCRIPTION
## Add Tableau Public Gallery to Dashboards & BI Resources

As suggested in issue #16 and confirmed by @PavelGrigoryevDS.

### What changed
Added Tableau Public Gallery under the Dashboards & BI → Resources section.

- [Tableau Public Gallery](https://public.tableau.com/app/discover) - A curated collection of real-world interactive dashboards to inspire and learn from.