### PR TITLE
Add StaticFeed to the list of Python libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ A collection of Python libraries for efficient data manipulation, cleaning, visu
 - [Numba](https://github.com/numba/numba) - A JIT compiler that translates a subset of Python and NumPy code into fast machine code.
 - [Pandas Stubs](https://github.com/pandas-dev/pandas-stubs) - Type stubs for pandas, improves IDE autocompletion.
 - [Petl](https://github.com/petl-developers/petl) - ETL tool for data cleaning and transformation.
+- [StaticFeed](https://github.com/jackydangelo/staticfeed) - A zero-cost, memory-efficient Python RSS data ingestion pipeline that fetches, normalizes, and deduplicates web feeds via GitHub Actions and Pages.
 
 [⬆ back to contents](#contents)
 


### PR DESCRIPTION
Hi @PavelGrigoryevDS! I would like to suggest StaticFeed for the "Python -> Useful Python Tools for Data Analysis" section.

It is a lightweight, serverless Python pipeline designed for structured web data ingestion. 
Key technical highlights:
- Stream-based processing using Python generators (yield) for a near-zero memory footprint.
- Connection pooling and exponential backoff retries via urllib3 for network resilience.
- URL-canonicalization layer for data deduplication.

It provides a production-ready, maintenance-free blueprint for data analysts who need to automate data collection from web feeds without incurring hosting costs.