### PR TITLE
Add csvtidy to PDF tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1605,7 +1605,7 @@ A collection of supplementary Python libraries that enhance development workflow
 - [PyMuPDF](https://github.com/pymupdf/PyMuPDF) - Advanced PDF manipulation library.
 - [Camelot](https://github.com/camelot-dev/camelot) - PDF table extraction library.
 - [Marker](https://github.com/datalab-to/marker) - Fast, high-accuracy PDF and document conversion tool with layout preservation.
-
+- [csvtidy](https://github.com/abhishekrai43/csvtidy) - Clean and merge messy CSV files from the command line; offline, DuckDB-powered (handles files bigger than RAM), recipe-driven.
 [⬆ back to contents](#contents)
 
 ---


### PR DESCRIPTION
Adding csvtidy, an open-source (MIT) command-line tool for cleaning and merging messy CSV files — trim, fix dates, dedupe, and combine a whole folder into one, driven by reusable recipes. It uses DuckDB under the hood, so it handles files larger than RAM. Installable via pip install csvtidy. I think it fits the [CSV / data-processing] section. Thanks for maintaining this list!