### PR TITLE
Add JSON Viewer Tool to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,6 +1247,7 @@ A collection of resources to enhance productivity.
 - [QuarkDown](https://github.com/iamgio/quarkdown) - Lightweight markdown processor for fast document rendering.
 - [screenshot-to-code](https://github.com/abi/screenshot-to-code) - AI tool that converts screenshots into code for various frontend stacks.
 - [Codebeautify](https://codebeautify.org/) - All-in-one online code formatter and beautifier for Python, SQL, JSON, and more.
+- [JSON Viewer Tool](https://jsonviewertool.com/) - Online JSON viewer and converter for turning API responses into CSV or Excel for analysis.
 - [Notion](https://www.notion.com/) - An all-in-one workspace for note-taking and task management.
 - [Trello](https://trello.com/home) - A visual project management tool.
 - [Habitica](https://github.com/HabitRPG/habitica) - A habit-building and productivity app that treats your life like a role-playing game.


### PR DESCRIPTION
Adds [JSON Viewer Tool](https://jsonviewertool.com/) next to the other online formatting utilities in the Resources section.

It's most relevant to data work for converting JSON (API responses, exports, logs) into CSV or Excel, plus viewing/validating deeply nested JSON before analysis. Free, no signup, and it runs entirely in the browser — nothing is uploaded — which helps when the payload contains data you can't send to a third-party server.

Disclosure: I maintain this site. Happy to adjust the description or drop it if it's not a fit for the list.