### PR TITLE
Add Dr. Claw research workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,6 +1030,7 @@ ogrammatically.
 - [Flowise](https://github.com/FlowiseAI/Flowise) - Open-source UI visual tool for building custom LLM orchestration flows and AI agents.
 - [MetaGPT](https://github.com/FoundationAgents/MetaGPT) - Multi-agent framework that simulates roles in a software company to build projects.
 - [Local Deep Research](https://github.com/LearningCircuit/local-deep-research) - Local AI research assistant that searches web, papers, and documents.
+- [Dr. Claw](https://github.com/OpenLAIR/dr-claw) - Open-source research workspace for literature surveys, local experiments, data analysis, and paper writing with multiple AI agent backends.
 - [Gptme](https://github.com/gptme/gptme) - AI agent CLI that writes code, uses terminal, browses web, and runs locally.
 - [Rowboat](https://github.com/rowboatlabs/rowboat) - Open-source AI coworker that learns from your emails/meetings to automate drafting, prep, and tasks.
 - [FutureSearch SDK](https://github.com/futuresearch/futuresearch-python) - Python SDK that dispatches parallel web-research agents across


### PR DESCRIPTION
## Summary

Add Dr. Claw to **AI Applications & Platforms → Tools → AI Agents & Automation**. It is a free, open-source research workspace that supports literature surveys, local experiment execution, data analysis, and paper writing through multiple agent backends.

This is one resource, uses the required name/link/brief-description format, and sits beside the existing Local Deep Research and other agent tools. Default-branch and all-state issue/PR searches found no Dr. Claw, `dr-claw`, or OpenLAIR duplicate; the canonical repository link returns HTTP 200.

I am submitting this on behalf of repository maintainer Yuxuan Zhang.