### PR TITLE
Add Pythonlings to Python resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ A collection of resources for learning and mastering Python programming.
 - [Awesome Python Data Science](https://github.com/krzjoa/awesome-python-data-science) - A curated list of Python resources for data science.
 - [Python Data Science Handbook](https://github.com/jakevdp/PythonDataScienceHandbook) - Full text of the "Python Data Science Handbook" in Jupyter Notebooks.
 - [Interactive Coding Challenges](https://github.com/donnemartin/interactive-coding-challenges) - 120+ interactive Python coding interview challenges.
+- [Pythonlings](https://github.com/abhiksark/pythonlings) - A terminal-based learning tool with 292 fix-and-verify exercises across 31 Python topics.
 - [Clean Code Python](https://github.com/zedr/clean-code-python) - Clean Code concepts adapted for Python.
 - [Best of Python](https://github.com/ml-tooling/best-of-python) - A ranked list of awesome Python open-source libraries and tools.
 - [GeeksforGeeks Python](https://www.geeksforgeeks.org/python-programming-language-tutorial/) - Python tutorial from GeeksforGeeks.


### PR DESCRIPTION
## Summary

Add Pythonlings to Python > Resources. It is a free, MIT-licensed terminal learning tool with 292 fix-and-verify exercises across 31 Python topics.

The change adds one resource in the required name, link, and brief-description format. It is placed beside the existing Interactive Coding Challenges entry. Searches of the default branch, open and closed issues, pull requests, and the suggestions thread found no duplicate.

## Disclosure

I maintain Pythonlings and am submitting my own project for consideration. The current release is v0.4.2, and the project describes itself as alpha.

## Validation

- `git diff --check`
- Confirmed the project URL returns HTTP 200.
- Installed `docs/requirements.txt` in an isolated virtual environment.
- Reproduced the workflow README preparation and ran `make -C docs html`; the Sphinx build succeeded.