### PR TITLE
Reposition csvtidy next to CleverCSV, shorten description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1605,7 +1605,7 @@ A collection of supplementary Python libraries that enhance development workflow
 - [PyMuPDF](https://github.com/pymupdf/PyMuPDF) - Advanced PDF manipulation library.
 - [Camelot](https://github.com/camelot-dev/camelot) - PDF table extraction library.
 - [Marker](https://github.com/datalab-to/marker) - Fast, high-accuracy PDF and document conversion tool with layout preservation.
-
+- [csvtidy](https://github.com/abhishekrai43/csvtidy) - Clean and merge messy CSV files from the command line; offline, DuckDB-powered (handles files bigger than RAM), recipe-driven.
 [⬆ back to contents](#contents)
 
 ---


### PR DESCRIPTION
My earlier PR #72 landed at the end of Documentation & File Processing, after the PDF tools. Moved it next to its closer sibling (CleverCSV, also a messy-CSV tool) and shortened the description to match neighboring entries' style per CONTRIBUTING.md ("keep descriptions short and factual").